### PR TITLE
add POC for theming in web components

### DIFF
--- a/apps/sales-pwa-app/src/components/theme/mock.component.ts
+++ b/apps/sales-pwa-app/src/components/theme/mock.component.ts
@@ -1,0 +1,35 @@
+import { html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { ThemeWrapper } from './theme.component';
+
+@customElement('av-mock-theme')
+export class MockComponent extends ThemeWrapper {
+  static styles = css`
+    :host {
+      color: #345432;
+    }
+
+    :host([theme='dark']) {
+      color: #ddd;
+    }
+  `;
+
+  render() {
+    return html`<div>
+      <h3>test theme</h3>
+      <button @click=${this._click}>toggle theme</button>
+    </div>`;
+  }
+
+  /**
+   * @description toggles theme between light and dark
+   */
+  _click() {
+    const userPrefersDark = window.matchMedia('prefers-color-scheme: dark)').matches;
+    const theme = localStorage.getItem('theme') || (userPrefersDark ? 'dark' : 'light');
+    const toggledTheme = theme === 'light' ? 'dark' : 'light';
+
+    document.documentElement.setAttribute('theme', toggledTheme);
+    localStorage.setItem('theme', toggledTheme);
+  }
+}

--- a/apps/sales-pwa-app/src/components/theme/theme.component.ts
+++ b/apps/sales-pwa-app/src/components/theme/theme.component.ts
@@ -1,0 +1,27 @@
+import { LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+declare type themeType = 'dark' | 'light' | '';
+declare class ThemeHost {
+  theme: themeType;
+}
+const registeredComponents: (ThemeHost & HTMLElement)[] = [];
+const themeObserver = new MutationObserver(() => {
+  registeredComponents.forEach((component) => {
+    component.theme = (document.documentElement.getAttribute('theme') || '') as themeType;
+  });
+});
+themeObserver.observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ['theme'],
+});
+
+export class ThemeWrapper extends LitElement {
+  @property({ reflect: true })
+  theme: themeType = '';
+
+  constructor() {
+    super();
+    registeredComponents.push(this);
+  }
+}

--- a/apps/sales-pwa-app/src/index.ts
+++ b/apps/sales-pwa-app/src/index.ts
@@ -6,3 +6,4 @@ export { OpportunityListPage } from './pages/opportunity/opportunity-list.page';
 export { OpportunityDetailPage } from './pages/opportunity/opportunity-detail.page';
 export { WorkerPage } from './pages/worker.page';
 export { ServiceWorkerPage } from './pages/service-worker.page';
+export { MockComponent } from './components/theme/mock.component';

--- a/apps/sales-pwa-app/src/pages/playgrounds.page.ts
+++ b/apps/sales-pwa-app/src/pages/playgrounds.page.ts
@@ -9,6 +9,7 @@ export class PlaygroundsPage extends ApplicationView {
       <h1>Playgrounds</h1>
       <av-button variant="primary">Primary</av-button>
       <av-paragraph>Hello world!</av-paragraph>
+      <av-mock-theme></av-mock-theme>
     </section> `;
   }
 }


### PR DESCRIPTION
1. POC uses javascript to assess if theme exist in local storage, otherwise uses os default.
2. Any lit component can extend via ThemeWrapper which automatically observes if theme attribute has changed between 'dark' and 'light.
3. Lit component can then create styles using css selector. Refer to mock.component.ts
